### PR TITLE
Fix incorrect CopyRuntimeDependencies.ProjectFile causing 'Could not find paket.dependencies'

### DIFF
--- a/src/Paket/PlatformTask.fs
+++ b/src/Paket/PlatformTask.fs
@@ -27,8 +27,8 @@ type CopyRuntimeDependencies() =
         and set(v) = projectsWithRuntimeLibs <- v
 
     member this.ProjectFile
-        with get() = outputPath
-        and set(v) = outputPath <- v
+        with get() = projectFile
+        and set(v) = projectFile <- v
 
     member this.TargetFramework
         with get() = targetFramework


### PR DESCRIPTION
 The `CopyRuntimeDependencies.ProjectFile` member was incorrectly set to the `outputPath` variable, instead of the `projectFile` one. This caused the `Dependencies.Locate` function to search in the wrong folder for the `project.dependencies` file.
